### PR TITLE
clean up avatar code, collision mask on box

### DIFF
--- a/demo/scenes/Godot Dojo.tscn
+++ b/demo/scenes/Godot Dojo.tscn
@@ -43,6 +43,7 @@ extents = Vector3( 0.7, 0.5, 0.1 )
 size = Vector3( 0.4, 0.4, 0.4 )
 
 [sub_resource type="BoxShape" id=12]
+margin = 0.02
 extents = Vector3( 0.2, 0.2, 0.2 )
 
 [node name="Godot Dojo" type="Spatial"]
@@ -264,6 +265,7 @@ shape = SubResource( 10 )
 
 [node name="DemoGrabCube" type="RigidBody" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, 1 )
+collision_mask = 131073
 script = ExtResource( 3 )
 reset_transform_on_pickup = false
 ranged_grab_method = 0


### PR DESCRIPTION
-Clean up avatar.gd comments
-Adjust avatar.gd comments for new magnet positions for arm IK
-Suggested fix for unexpected reversion of avatar scaling in physics process - by turning on debug print function you can see that after the global_transform line runs in the physics process, it unexpectedly reverts the $Armature.scale value back to pre-ready function values.  The new line of code is intended to address this issue.
-Add a collision mask to the box to allow physical hitting of it with the physics hands in addition to grabbing.