### PR TITLE
fix slicer mechanic

### DIFF
--- a/addons/godot-xr-tools/assets/HandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/HandBlendTree.tres
@@ -30,4 +30,4 @@ nodes/Grip/position = Vector2( 780, 180 )
 nodes/Trigger/node = SubResource( 2 )
 nodes/Trigger/position = Vector2( 560, 80 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "output", 0, "Grip", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "Trigger", 0, "Default", "Trigger", 1, "Fist" ]
+node_connections = [ "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "output", 0, "Grip" ]

--- a/addons/slicer/sliceable_geo.gd
+++ b/addons/slicer/sliceable_geo.gd
@@ -64,8 +64,8 @@ func _create_cut_body(_sign,mesh_instance,cutplane : Plane):
 				#print("using cross section material")
 				#print(mat)
 			else:
-#				mat = _mesh.mesh.surface_get_material(i) #this was not working properly
-				mat = _cross_section_material
+				mat = _mesh.mesh.surface_get_material(i) #this was not working properly
+#				mat = _cross_section_material
 				#print("using regular materal")
 				#print(mat)
 			object.mesh.surface_set_material(i,mat)

--- a/addons/slicer/slicer.gd
+++ b/addons/slicer/slicer.gd
@@ -5,19 +5,28 @@ extends Area
 var plane_point_a:Vector3
 var plane_point_b:Vector3
 var plane_point_c:Vector3
-
-
+var entered_mesh = false
+var cut_plane:Plane
 	
 
 
-func _on_Area_body_entered(body):
-	pass
 	
-
 
 func _on_SlicingArea_body_exited(body):
+	if body is sliceable and entered_mesh == true:
+#		plane_point_a = $mesh/A.global_transform.origin
+#		plane_point_b = $mesh/B.global_transform.origin
+#		plane_point_c = $mesh/C.global_transform.origin
+#		body.cut_object(Plane(plane_point_a,plane_point_b,plane_point_c))# Replace with function body.
+		body.cut_object(cut_plane)
+		entered_mesh = false
+
+#create cutting plane on enter instead of exit to better meet user's expecatations of how slice will happen
+func _on_SlicingArea_body_entered(body):
 	if body is sliceable:
-		plane_point_a = $mesh/A.global_transform.origin
-		plane_point_b = $mesh/B.global_transform.origin
-		plane_point_c = $mesh/C.global_transform.origin
-		body.cut_object(Plane(plane_point_a,plane_point_b,plane_point_c))# Replace with function body.
+		if entered_mesh == false:
+			plane_point_a = $mesh/A.global_transform.origin
+			plane_point_b = $mesh/B.global_transform.origin
+			plane_point_c = $mesh/C.global_transform.origin
+			cut_plane = Plane(plane_point_a,plane_point_b,plane_point_c)
+			entered_mesh = true

--- a/demo/scenes/Godot Dojo.tscn
+++ b/demo/scenes/Godot Dojo.tscn
@@ -270,6 +270,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.2, 2.7571 )
 collision_layer = 131073
 collision_mask = 131073
 script = ExtResource( 3 )
+reset_transform_on_pickup = false
 ranged_grab_method = 0
 
 [node name="MeshInstance" type="MeshInstance" parent="DemoGrabCube"]

--- a/demo/scenes/mapobjects/SliceableWoodenman.tscn
+++ b/demo/scenes/mapobjects/SliceableWoodenman.tscn
@@ -12,6 +12,7 @@ surfaces/0 = {
 "blend_shape_data": [  ],
 "format": 2194711,
 "index_count": 1920,
+"material": ExtResource( 2 ),
 "primitive": 4,
 "skeleton_aabb": [  ],
 "vertex_count": 481
@@ -31,7 +32,6 @@ _cross_section_material = ExtResource( 2 )
 [node name="MeshInstance" type="MeshInstance" parent="."]
 transform = Transform( 1, 0, 0, 0, -1.19209e-07, -1, 0, 1, -1.19209e-07, 0, 0, 0 )
 mesh = SubResource( 1 )
-material/0 = ExtResource( 2 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
 transform = Transform( 1, 0, 0, 0, -4.37114e-08, -1, 0, 1, -4.37114e-08, 0, 0, 0 )

--- a/demo/scenes/weapons/Slicing_Katana_Long.tscn
+++ b/demo/scenes/weapons/Slicing_Katana_Long.tscn
@@ -94,4 +94,5 @@ collision_mask = 131072
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.367767, -0.00441357, 0 )
 shape = SubResource( 9 )
 
+[connection signal="body_entered" from="SlicingArea" to="SlicingArea" method="_on_SlicingArea_body_entered"]
 [connection signal="body_exited" from="SlicingArea" to="SlicingArea" method="_on_SlicingArea_body_exited"]


### PR DESCRIPTION
-set slicing plane at enter instead of exit to better meet user expectations
-revert change to slicer code regarding material (user error, code expects material to be on mesh not an override)
-revert accidental change to cube to reset transform for now