### PR TITLE
Avatar code clean up

### DIFF
--- a/addons/godot-xr-tools/assets/HandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/HandBlendTree.tres
@@ -30,4 +30,4 @@ nodes/Grip/position = Vector2( 780, 180 )
 nodes/Trigger/node = SubResource( 2 )
 nodes/Trigger/position = Vector2( 560, 80 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "output", 0, "Grip" ]
+node_connections = [ "output", 0, "Grip", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "Trigger", 0, "Default", "Trigger", 1, "Fist" ]


### PR DESCRIPTION
-Shift from total reliance on controller nodes to make way for potential hand tracking support someday
-Child left_hand_target and right_hand_target nodes directly to hand nodes instead of to controller nodes
-Insert conditional before setting hand animation blends to check if controller paths are set, if not, print message and do not set hand animation blends
-Don't try to find controllers again for animation hand blends; just use controller nodes already set in code
-To do - replicate code changes in shadows