### PR TITLE
Implement pickable shard template for destruction plugin

### DIFF
--- a/addons/destruction/DestructionUtils.gd
+++ b/addons/destruction/DestructionUtils.gd
@@ -6,7 +6,7 @@ static func create_shards(object : Spatial, shard_template : PackedScene = prelo
 		if not shard_mesh is MeshInstance:
 			continue
 		reposition_mesh_to_middle(shard_mesh)
-		var new_shard : RigidBody = shard_template.instance()
+		var new_shard = shard_template.instance()
 		new_shard.translation = shard_mesh.translation
 		new_shard.name = new_shard.name.format(
 				{name = object.name, number = shard_num})

--- a/addons/destruction/ShardTemplates/PickableShardTemplate.tscn
+++ b/addons/destruction/ShardTemplates/PickableShardTemplate.tscn
@@ -1,0 +1,9 @@
+[gd_scene load_steps=2 format=2]
+
+[ext_resource path="res://addons/godot-xr-tools/objects/Object_pickable.tscn" type="PackedScene" id=1]
+
+[node name="{name}Shard{number}" instance=ExtResource( 1 )]
+collision_layer = 131073
+ranged_grab_method = 0
+
+[node name="MeshInstance" type="MeshInstance" parent="." index="2"]

--- a/dojo/DestructableTable.tscn
+++ b/dojo/DestructableTable.tscn
@@ -1,9 +1,10 @@
-[gd_scene load_steps=8 format=2]
+[gd_scene load_steps=9 format=2]
 
 [ext_resource path="res://dojo/mat_table_round.tres" type="Material" id=1]
 [ext_resource path="res://dojo/Table_shards.tscn" type="PackedScene" id=2]
 [ext_resource path="res://addons/destruction/destruction.gd" type="Script" id=3]
 [ext_resource path="res://dojo/DestructableTable.gd" type="Script" id=4]
+[ext_resource path="res://addons/destruction/ShardTemplates/PickableShardTemplate.tscn" type="PackedScene" id=5]
 
 [sub_resource type="ArrayMesh" id=1]
 resource_name = "furniture_table_round_Plane002"
@@ -38,6 +39,7 @@ mesh = SubResource( 1 )
 
 [node name="Destruction" type="Node" parent="BreakableObject"]
 script = ExtResource( 3 )
+shard_template = ExtResource( 5 )
 shard_scene = ExtResource( 2 )
 
 [node name="Area" type="Area" parent="."]

--- a/make_human_demo/scenes/Godot Dojo_Shurikens.tscn
+++ b/make_human_demo/scenes/Godot Dojo_Shurikens.tscn
@@ -22,28 +22,6 @@
 
 [node name="avatar_player" parent="." instance=ExtResource( 9 )]
 
-[node name="Skeleton" parent="avatar_player/FPController/LeftHandController/LeftPhysicsHand/LeftHand/Armature_Left" index="0"]
-bones/0/bound_children = [  ]
-bones/1/bound_children = [  ]
-bones/2/bound_children = [  ]
-bones/3/bound_children = [  ]
-bones/4/bound_children = [  ]
-bones/5/bound_children = [  ]
-bones/6/bound_children = [  ]
-bones/7/bound_children = [  ]
-bones/8/bound_children = [  ]
-bones/9/bound_children = [  ]
-bones/10/bound_children = [  ]
-bones/11/bound_children = [  ]
-bones/12/bound_children = [  ]
-bones/13/bound_children = [  ]
-bones/14/bound_children = [  ]
-bones/15/bound_children = [  ]
-bones/16/bound_children = [  ]
-bones/17/bound_children = [  ]
-bones/18/bound_children = [  ]
-bones/19/bound_children = [  ]
-
 [node name="BoneRoot" parent="avatar_player/FPController/LeftHandController/LeftPhysicsHand/LeftHand/Armature_Left/Skeleton" index="1"]
 transform = Transform( 1, -2.50192e-40, 1.51496e-08, 1.51445e-08, -0.025905, -0.999665, 3.92449e-10, 0.999664, -0.025905, 7.2293e-21, 0.000360775, -0.0235019 )
 

--- a/managers/WeaponManager.gd
+++ b/managers/WeaponManager.gd
@@ -34,6 +34,8 @@ func _ready():
 	#pass
 func _on_left_function_pickup_picked_up_object(object):
 	var weapon_to_hold_scene = check_weapon_scene(object)
+	if weapon_to_hold_scene == null:
+		return
 	if object.get_node_or_null("holder") != null:
 		object.get_node("holder").visible = false
 	shadow_group = get_tree().get_nodes_in_group("shadows")
@@ -55,7 +57,9 @@ func _on_left_function_pickup_picked_up_object(object):
 func _on_left_function_pickup_dropped_object():
 #	if item_in_player_hand_left.get_node_or_null("holder") != null:
 #		item_in_player_hand_left.get_node("holder").visible = true
-	
+	if item_in_player_hand_left == null:
+		return
+		
 	shadow_group = get_tree().get_nodes_in_group("shadows")
 	
 	for shadow in shadow_group:
@@ -70,6 +74,8 @@ func _on_left_function_pickup_dropped_object():
 	
 func _on_right_function_pickup_picked_up_object(object):
 	var weapon_to_hold_scene = check_weapon_scene(object)
+	if weapon_to_hold_scene == null:
+		return
 	if object.get_node_or_null("holder") != null:
 		object.get_node("holder").visible = false
 	shadow_group = get_tree().get_nodes_in_group("shadows")
@@ -91,7 +97,9 @@ func _on_right_function_pickup_picked_up_object(object):
 func _on_right_function_pickup_dropped_object():
 #	if item_in_player_hand_right.get_node_or_null("holder") != null:
 #		item_in_player_hand_right.get_node("holder").visible = true
-	
+	if item_in_player_hand_right == null:
+		return
+		
 	shadow_group = get_tree().get_nodes_in_group("shadows")
 	
 	for shadow in shadow_group:
@@ -123,3 +131,4 @@ func check_weapon_scene(object):
 		return shuriken_8star_scene
 	elif object.name.begins_with("Shuriken"):
 		return shuriken_scene
+	return null


### PR DESCRIPTION
-Add new shard template for pickable objects when using destruction add on

-Set pickable object template for destructable table in Shurikens Make Human Demo

-Adjust weapon manager script to account for player potentially holding something other than a designated weapon (pieces of broken table) to avoid errors