### PR TITLE
Backpack and Haptic manager fixes

### DIFF
--- a/addons/godot-xr-avatar/scenes/avatar_player_SnapZones.tscn
+++ b/addons/godot-xr-avatar/scenes/avatar_player_SnapZones.tscn
@@ -333,28 +333,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
 collision_layer = 655360
 margin = 0.004
 
-[node name="Skeleton" parent="FPController/LeftHandController/LeftPhysicsHand/LeftHand/Armature_Left" index="0"]
-bones/0/bound_children = [  ]
-bones/1/bound_children = [  ]
-bones/2/bound_children = [  ]
-bones/3/bound_children = [  ]
-bones/4/bound_children = [  ]
-bones/5/bound_children = [  ]
-bones/6/bound_children = [  ]
-bones/7/bound_children = [  ]
-bones/8/bound_children = [  ]
-bones/9/bound_children = [  ]
-bones/10/bound_children = [  ]
-bones/11/bound_children = [  ]
-bones/12/bound_children = [  ]
-bones/13/bound_children = [  ]
-bones/14/bound_children = [  ]
-bones/15/bound_children = [  ]
-bones/16/bound_children = [  ]
-bones/17/bound_children = [  ]
-bones/18/bound_children = [  ]
-bones/19/bound_children = [  ]
-
 [node name="BoneRoot" parent="FPController/LeftHandController/LeftPhysicsHand/LeftHand/Armature_Left/Skeleton" index="1"]
 transform = Transform( 1, -2.50192e-40, 1.51496e-08, 1.51445e-08, -0.025905, -0.999665, 3.92449e-10, 0.999664, -0.025905, 7.2293e-21, 0.000360775, -0.0235019 )
 
@@ -448,6 +426,8 @@ left_hand_path = NodePath("../LeftHandController/LeftPhysicsHand")
 right_hand_path = NodePath("../RightHandController/RightPhysicsHand")
 head_mesh_node_paths = [ NodePath("Armature/Skeleton/mesh_Eyes"), NodePath("Armature/Skeleton/mesh_Head"), NodePath("Armature/Skeleton/mesh_Visor") ]
 auto_anim_choice = 1
+use_procedural_walk = true
+use_procedural_bounce = true
 
 [node name="Armature" type="Spatial" parent="FPController/avatar"]
 transform = Transform( 1, 0, 0, 0, 1, 1.62921e-07, 0, -1.62921e-07, 1, 0, 0, 0 )

--- a/addons/godot-xr-avatar/scripts/automated_avatar.gd
+++ b/addons/godot-xr-avatar/scripts/automated_avatar.gd
@@ -148,7 +148,7 @@ onready var skeleton : Skeleton = $Armature/Skeleton
 func _ready():
 	#Display warning message if no animation tree or animation player found
 	if (get_node_or_null("AnimationTree") == null or get_node_or_null("AnimationPlayer") == null) and auto_anim_choice == AutomaticAnimation.NO:
-		print("Either or both of the AnimationTree and AnimationPlayer nodes not found, and auto animation not set to procedural, animations will not work.")
+		print("Either or both of the AnimationTree and AnimationPlayer nodes not found, and auto animation set to no, so animations will not work.")
 	
 	#turn skeleton by 180 degrees if set by export variable (default) so facing the correct direction
 	if turn_character_180 == true:

--- a/addons/godot-xr-tools/assets/HandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/HandBlendTree.tres
@@ -30,4 +30,4 @@ nodes/Grip/position = Vector2( 780, 180 )
 nodes/Trigger/node = SubResource( 2 )
 nodes/Trigger/position = Vector2( 560, 80 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "output", 0, "Grip" ]
+node_connections = [ "output", 0, "Grip", "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2" ]

--- a/dojo/backpack/Backpack.tscn
+++ b/dojo/backpack/Backpack.tscn
@@ -6,25 +6,27 @@
 [ext_resource path="res://weapons/trailmaterial.tres" type="Material" id=4]
 [ext_resource path="res://dojo/backpack/ring_long.png" type="Texture" id=6]
 
-[sub_resource type="SphereShape" id=16]
+[sub_resource type="BoxShape" id=16]
+extents = Vector3( 0.175, 0.25, 0.1 )
 
 [sub_resource type="SphereMesh" id=15]
 radius = 0.075
 height = 0.15
 
-[node name="Backpack" type="RigidBody"]
+[node name="Backpack" type="RigidBody" groups=["Heavy"]]
 collision_mask = 131073
-mode = 1
 script = ExtResource( 1 )
 __meta__ = {
 "_editor_description_": ""
 }
+reset_transform_on_pickup = false
+ranged_grab_method = 0
 
 [node name="PickupCenter" type="Spatial" parent="."]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.108375, -0.117393 )
 
 [node name="CollisionShape" type="CollisionShape" parent="."]
-transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.09374, 0 )
+transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.0351656, 0 )
 shape = SubResource( 16 )
 
 [node name="In" type="Spatial" parent="."]
@@ -178,7 +180,7 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0.00739692, 0 )
 
 [node name="Snap_Zone" parent="Out" groups=["User"] instance=ExtResource( 3 )]
 transform = Transform( 1, -1.0626e-14, 1.73119e-21, 1.0626e-14, 1, -1.6292e-07, 0, 1.6292e-07, 1, 0.150459, 0.2, 0 )
-snap_require = "Heavy"
+snap_exclude = "Heavy"
 
 [node name="MeshInstance" type="MeshInstance" parent="Out/Snap_Zone"]
 visible = false
@@ -191,7 +193,7 @@ texture = ExtResource( 6 )
 
 [node name="Snap_Zone2" parent="Out" groups=["User"] instance=ExtResource( 3 )]
 transform = Transform( 1, -1.0626e-14, 1.73119e-21, 1.0626e-14, 1, -1.6292e-07, 0, 1.6292e-07, 1, -0.165119, 0.2, 0 )
-snap_require = "Heavy"
+snap_exclude = "Heavy"
 
 [node name="MeshInstance" type="MeshInstance" parent="Out/Snap_Zone2"]
 visible = false
@@ -213,7 +215,3 @@ transform = Transform( 0.866025, 0.5, 0, -0.5, 0.866025, 0, 0, 0, 1, -0.0134399,
 width = 0.0343187
 height = 0.458297
 depth = 0.0522192
-
-[connection signal="action_pressed" from="." to="." method="_on_Backpack_action_pressed"]
-[connection signal="dropped" from="." to="." method="_on_Backpack_dropped"]
-[connection signal="picked_up" from="." to="." method="_on_Backpack_picked_up"]

--- a/dojo/holster/HolsterHelper.gd
+++ b/dojo/holster/HolsterHelper.gd
@@ -5,7 +5,7 @@ var currentPosition;
 var movePosition;
 var targetPosition;
 var distance =  0.02;
-var time_to_move = 0.5;
+
 export (NodePath) var arvrcamera_path = null
 #export var holster_move_speed = 10
 
@@ -25,8 +25,7 @@ func _ready():
 	
 	pass # Replace with function body.
 
-var moving = false;
-var moveTimer = 0.0;
+
 
 func _process(dt):
 	var viewDir = -vrCamera.global_transform.basis.z;
@@ -35,22 +34,10 @@ func _process(dt):
 	
 	var camPos = vrCamera.global_transform.origin;
 
-	#TODO: rotate instead of move
+
 	targetPosition = camPos + viewDir * distance;
-#	var distToTarget = (targetPosition - currentPosition).length();
-#	if moving:
-#		currentPosition = currentPosition + (movePosition - currentPosition) * holster_move_speed * dt;
-#		if (distToTarget < 0.05):
-#			moving = false;
-	currentPosition = targetPosition #trying this to make move instantaneous
+#	
+	currentPosition = targetPosition 
 			
-#	if (distToTarget > 0.5):
-#		moveTimer += dt;
-#	else:
-#		moveTimer = 0.0;
-			
-#	if (moveTimer > time_to_move):
-#		moving = true;
-#		movePosition = targetPosition;
 
 	look_at_from_position(currentPosition, camPos, Vector3(0,1,0));

--- a/make_human_demo/scenes/Godot Dojo_SnapZone_Inventory.tscn
+++ b/make_human_demo/scenes/Godot Dojo_SnapZone_Inventory.tscn
@@ -102,3 +102,6 @@ script = null
 
 [node name="Backpack" parent="." instance=ExtResource( 11 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.184375, 1.11168, -1.41673 )
+reset_transform_on_pickup = true
+
+[connection signal="dropped" from="Backpack" to="WeaponManager" method="_on_Backpack_dropped"]

--- a/managers/HapticManager.gd
+++ b/managers/HapticManager.gd
@@ -14,17 +14,20 @@ func _ready():
 	arvrorigin = get_parent().get_node("avatar_player").get_node("FPController") # Replace with function body.
 	left_controller = ARVRHelpers.get_left_controller(arvrorigin)
 	right_controller = ARVRHelpers.get_right_controller(arvrorigin)
-	left_controller.get_node("Function_Pickup").connect("has_picked_up", self, "haptic_pulse_on_pickup")
-	right_controller.get_node("Function_Pickup").connect("has_picked_up", self, "haptic_pulse_on_pickup")
-
-#commented out since it crashes currently with backpack
-#func haptic_pulse_on_pickup(what):
-#	#What is passed as a parameter by the has_picked_up signal and is the object pickable, in turn that has a _by_controller property that yield the picked up controller
-#	what.by_controller.set_rumble(0.2)
-#	yield(get_tree().create_timer(0.2), "timeout")
-#	what.by_controller.set_rumble(0.0)# Replace with function body.
+	left_controller.get_node("Function_Pickup").connect("has_picked_up", self, "left_haptic_pulse_on_pickup")
+	right_controller.get_node("Function_Pickup").connect("has_picked_up", self, "right_haptic_pulse_on_pickup")
 
 
+func left_haptic_pulse_on_pickup(_what):
+	left_controller.set_rumble(0.2)
+	yield(get_tree().create_timer(0.2), "timeout")
+	left_controller.set_rumble(0.0)
+
+func right_haptic_pulse_on_pickup(_what):
+	right_controller.set_rumble(0.2)
+	yield(get_tree().create_timer(0.2), "timeout")
+	right_controller.set_rumble(0.0)
+	
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	pass

--- a/managers/WeaponManager.gd
+++ b/managers/WeaponManager.gd
@@ -7,7 +7,8 @@ onready var shuriken_scene = load("res://weapons/Throwing_Shuriken.tscn")
 onready var shuriken_4spike_scene = load("res://weapons/Throwing_Shuriken_4Spike.tscn")
 onready var shuriken_4star_scene = load("res://weapons/Throwing_Shuriken_4Star.tscn")
 onready var shuriken_8star_scene = load("res://weapons/Throwing_Shuriken_8Star.tscn")
-
+onready var backpack_scene = load("res://dojo/backpack/Backpack.tscn")
+onready var backpack = get_parent().get_node_or_null("Backpack")
 var shadow_group := []
 var sword_group := []
 var shuriken_group := []
@@ -29,15 +30,42 @@ func _ready():
 	get_parent().get_node("HolderForPickableSwords/Snap_Zone").connect("has_picked_up", self, "_on_snap_zone_picked_up_object")
 	get_parent().get_node("HolderForPickableSwords/Snap_Zone2").connect("has_picked_up", self, "_on_snap_zone_picked_up_object")
 	get_parent().get_node("HolderForPickableSwords/Snap_Zone3").connect("has_picked_up", self, "_on_snap_zone_picked_up_object")
+	if backpack != null:
+		var inner_pack = backpack.get_node("In")
+		var outer_pack = backpack.get_node("Out")
+		var inner_snaps = inner_pack.get_children()
+		var outer_snaps = outer_pack.get_children()
+		for snap in inner_snaps:
+			snap.grap_require = "disabled"
+			#snap.grab_distance = .10
+		for snap in outer_snaps:
+			snap.grap_require = "disabled"
+			#snap.grab_distance = .10
+		
+
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 #func _process(delta):
 	#pass
 func _on_left_function_pickup_picked_up_object(object):
 	var weapon_to_hold_scene = check_weapon_scene(object)
+	
 	if weapon_to_hold_scene == null:
 		return
+	
+	if weapon_to_hold_scene == backpack_scene:
+		var inner_pack = object.get_node("In")
+		var outer_pack = object.get_node("Out")
+		var inner_snaps = inner_pack.get_children()
+		var outer_snaps = outer_pack.get_children()
+		for snap in inner_snaps:
+			snap.grap_require = ""
+		for snap in outer_snaps:
+			snap.grap_require = ""
+		return
+		
 	if object.get_node_or_null("holder") != null:
 		object.get_node("holder").visible = false
+	
 	shadow_group = get_tree().get_nodes_in_group("shadows")
 	for shadow in shadow_group:
 		var held_weapon = weapon_to_hold_scene.instance()
@@ -74,10 +102,24 @@ func _on_left_function_pickup_dropped_object():
 	
 func _on_right_function_pickup_picked_up_object(object):
 	var weapon_to_hold_scene = check_weapon_scene(object)
+	
 	if weapon_to_hold_scene == null:
 		return
+	
+	if weapon_to_hold_scene == backpack_scene:
+		var inner_pack = object.get_node("In")
+		var outer_pack = object.get_node("Out")
+		var inner_snaps = inner_pack.get_children()
+		var outer_snaps = outer_pack.get_children()
+		for snap in inner_snaps:
+			snap.grap_require = ""
+		for snap in outer_snaps:
+			snap.grap_require = ""
+		return
+	
 	if object.get_node_or_null("holder") != null:
 		object.get_node("holder").visible = false
+	
 	shadow_group = get_tree().get_nodes_in_group("shadows")
 	for shadow in shadow_group:
 		var held_weapon = weapon_to_hold_scene.instance()
@@ -117,6 +159,8 @@ func _on_snap_zone_picked_up_object(object):
 		object.get_node("holder").visible = true
 
 func check_weapon_scene(object):
+	if object.name.begins_with("Backpack"):
+		return backpack_scene
 	if object.name.begins_with("Slicing_Katana_Long"):
 		return long_sword_scene
 	elif object.name.begins_with("Slicing_Katana_M"):
@@ -132,3 +176,17 @@ func check_weapon_scene(object):
 	elif object.name.begins_with("Shuriken"):
 		return shuriken_scene
 	return null
+
+
+func _on_Backpack_dropped(pickable):
+	var inner_pack = pickable.get_node("In")
+	var outer_pack = pickable.get_node("Out")
+	var inner_snaps = inner_pack.get_children()
+	var outer_snaps = outer_pack.get_children()
+	for snap in inner_snaps:
+		snap.grap_require = "none"
+		
+	for snap in outer_snaps:
+		snap.grap_require = "none"
+	
+


### PR DESCRIPTION
-Fix haptic manager to use separate signal receiver scripts for left and right function pickups to avoid bugs/crashes

-Make backpack rigid body so it can be placed, picked up, and put into body holsters

-Add backpack into "heavy" category to avoid backpack becoming stuck in infinite loop of being inside its own snap zones

-Add weapon manager code to address picking up of backpack and enabling/disabling snap zones to avoid accidental grabs of weapons inside when intending to grab backpack

-TO DO: adjust back body snap zones in snap zone demo scene so that if backpack is in snap zone, backpack origin is translated to be behind the player like a real backpack instead of in the middle of player's body