### PR TITLE
-Fix bug on release of weapon with secondary grab

### DIFF
--- a/addons/godot-xr-avatar/scripts/Function_Pickup_Avatar_Precise_Throwing.gd
+++ b/addons/godot-xr-avatar/scripts/Function_Pickup_Avatar_Precise_Throwing.gd
@@ -361,10 +361,11 @@ func _get_closest_ranged() -> Spatial:
 func drop_object() -> void:
 	if not is_instance_valid(picked_up_object):
 		return
-	
-	if picked_up_object.find_node("secondary_grab_area"):
-		picked_up_object.find_node("secondary_grab_area").disconnect("secondary_grab_area_grabbed", self, "_on_secondary_grab_area_grabbed")
-		picked_up_object.find_node("secondary_grab_area").disconnect("secondary_grab_area_released", self, "_on_secondary_grab_area_released")
+	var secondary_grab_area = picked_up_object.find_node("secondary_grab_area")
+	if secondary_grab_area != null:
+		secondary_grab_area.release()
+		secondary_grab_area.disconnect("secondary_grab_area_grabbed", self, "_on_secondary_grab_area_grabbed")
+		secondary_grab_area.disconnect("secondary_grab_area_released", self, "_on_secondary_grab_area_released")
 	
 	#Default function pickup behavior
 	if use_precise_aiming == false or (use_precise_aiming == true and !_controller.is_button_pressed(precise_aim_activate_button_id)): # let go of this object

--- a/addons/godot-xr-avatar/scripts/secondary_grab_area.gd
+++ b/addons/godot-xr-avatar/scripts/secondary_grab_area.gd
@@ -43,3 +43,7 @@ func _on_secondary_grab_area_entered(_body):
 	
 func _on_secondary_grab_area_exited(_body):
 	_start_monitoring = false
+	
+func release():
+	if _gripping_controller != null:
+		emit_signal("secondary_grab_area_released", self, $grip_point, _gripping_controller)

--- a/addons/godot-xr-tools/assets/HandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/HandBlendTree.tres
@@ -30,4 +30,4 @@ nodes/Grip/position = Vector2( 780, 180 )
 nodes/Trigger/node = SubResource( 2 )
 nodes/Trigger/position = Vector2( 560, 80 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "output", 0, "Grip" ]
+node_connections = [ "output", 0, "Grip", "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2" ]


### PR DESCRIPTION
-On release of weapon with secondary grab, fix bug where if second hand still connected it would go haywire.

-Add public function to secondary grab area to release it so other functions can call it as necessary (necessary for bug fix above)