### PR TITLE
Work on secondary grab area / avatar grab scene

### DIFF
--- a/addons/godot-xr-avatar/scripts/secondary_grab_area.gd
+++ b/addons/godot-xr-avatar/scripts/secondary_grab_area.gd
@@ -3,6 +3,10 @@ extends Area
 signal secondary_grab_area_grabbed(grab_area, grip_point, by_controller)
 signal secondary_grab_area_released(grab_area, grip_point, by_controller)
 
+export var secondary_grab_area_local_position_left : Vector3 = Vector3(-.03, 0, 0) 
+export var secondary_grab_area_rotation_degrees_left : Vector3 = Vector3(0, 45, -90)
+export var secondary_grab_area_local_position_right : Vector3 = Vector3(.03, 0, 0)
+export var secondary_grab_area_rotation_degrees_right : Vector3 = Vector3(180, 135, -90)
 var _start_monitoring : bool = false
 var _overlapping_bodies : Array = []
 var _overlapping_controller : ARVRController = null
@@ -12,7 +16,8 @@ var _gripping_controller : ARVRController = null
 func _ready():
 	self.connect("body_entered", self, "_on_secondary_grab_area_entered")
 	self.connect("body_exited", self, "_on_secondary_grab_area_exited")
-
+	$grip_point.translation = secondary_grab_area_local_position_left
+	$grip_point.rotation_degrees = secondary_grab_area_rotation_degrees_left
 # Called every frame. 'delta' is the elapsed time since the previous frame.
 func _process(delta):
 	if _start_monitoring == true:

--- a/addons/godot-xr-tools/assets/HandBlendTree.tres
+++ b/addons/godot-xr-tools/assets/HandBlendTree.tres
@@ -30,4 +30,4 @@ nodes/Grip/position = Vector2( 780, 180 )
 nodes/Trigger/node = SubResource( 2 )
 nodes/Trigger/position = Vector2( 560, 80 )
 nodes/output/position = Vector2( 1020, 80 )
-node_connections = [ "output", 0, "Grip", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "Trigger", 0, "Default", "Trigger", 1, "Fist" ]
+node_connections = [ "Trigger", 0, "Default", "Trigger", 1, "Fist", "Grip", 0, "Trigger", "Grip", 1, "Fist2", "output", 0, "Grip" ]

--- a/make_human_demo/scenes/Godot Dojo.tscn
+++ b/make_human_demo/scenes/Godot Dojo.tscn
@@ -684,28 +684,6 @@ transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, -0.03, -0.05, 0.15 )
 collision_layer = 655360
 margin = 0.004
 
-[node name="Skeleton" parent="avatar_player/FPController/LeftHandController/LeftPhysicsHand/LeftHand/Armature_Left" index="0"]
-bones/0/bound_children = [  ]
-bones/1/bound_children = [  ]
-bones/2/bound_children = [  ]
-bones/3/bound_children = [  ]
-bones/4/bound_children = [  ]
-bones/5/bound_children = [  ]
-bones/6/bound_children = [  ]
-bones/7/bound_children = [  ]
-bones/8/bound_children = [  ]
-bones/9/bound_children = [  ]
-bones/10/bound_children = [  ]
-bones/11/bound_children = [  ]
-bones/12/bound_children = [  ]
-bones/13/bound_children = [  ]
-bones/14/bound_children = [  ]
-bones/15/bound_children = [  ]
-bones/16/bound_children = [  ]
-bones/17/bound_children = [  ]
-bones/18/bound_children = [  ]
-bones/19/bound_children = [  ]
-
 [node name="BoneRoot" parent="avatar_player/FPController/LeftHandController/LeftPhysicsHand/LeftHand/Armature_Left/Skeleton" index="1"]
 transform = Transform( 1, 0, 1.51496e-08, 1.51445e-08, -0.025905, -0.999665, 3.92449e-10, 0.999664, -0.025905, 0, 0.000360775, -0.0235019 )
 

--- a/weapons_CC0/Gun_Automatic_AK.tscn
+++ b/weapons_CC0/Gun_Automatic_AK.tscn
@@ -266,9 +266,6 @@ material/0 = ExtResource( 1 )
 [node name="secondary_grab_area" parent="." instance=ExtResource( 5 )]
 transform = Transform( 1, 0, 0, 0, 1, 0, 0, 0, 1, 0, -0.0373259, -0.0196273 )
 
-[node name="grip_point" parent="secondary_grab_area" index="1"]
-transform = Transform( 1.91069e-15, -4.37114e-08, 1, -1, -4.37114e-08, 0, 4.37114e-08, -1, -4.37114e-08, 0, 0, 0 )
-
 [node name="ClickSound" type="AudioStreamPlayer3D" parent="."]
 stream = ExtResource( 6 )
 


### PR DESCRIPTION
-Allow user to set left hand and right hand positions and rotations of secondary grab area grip point

-Adjust secondary grip point position and rotation for AK 47 test gun for more natural hand pose

-Clean up lines of code no longer needed in weapon_base.gd thanks to changes to secondary grab area code